### PR TITLE
Adds CookiePath to SessionDefaults

### DIFF
--- a/src/Microsoft.AspNet.Session/SessionDefaults.cs
+++ b/src/Microsoft.AspNet.Session/SessionDefaults.cs
@@ -8,5 +8,6 @@ namespace Microsoft.AspNet.Session
     public static class SessionDefaults
     {
         public static string CookieName = ".AspNet.Session";
+		public static string CookiePath = "/";
     }
 }

--- a/src/Microsoft.AspNet.Session/SessionMiddleware.cs
+++ b/src/Microsoft.AspNet.Session/SessionMiddleware.cs
@@ -127,7 +127,7 @@ namespace Microsoft.AspNet.Session
                 {
                     Domain = _options.CookieDomain,
                     HttpOnly = _options.CookieHttpOnly,
-                    Path = _options.CookiePath ?? "/",
+                    Path = _options.CookiePath ?? SessionDefaults.CookiePath,
                 };
 
                 _context.Response.Cookies.Append(_options.CookieName, _sessionKey, cookieOptions);

--- a/src/Microsoft.AspNet.Session/SessionOptions.cs
+++ b/src/Microsoft.AspNet.Session/SessionOptions.cs
@@ -20,7 +20,7 @@ namespace Microsoft.AspNet.Session
         /// <summary>
         /// Determines the path used to create the cookie. The default value is "/" for highest browser compatibility.
         /// </summary>
-        public string CookiePath { get; set; } = "/";
+        public string CookiePath { get; set; } = SessionDefaults.CookiePath;
 
         /// <summary>
         /// Determines if the browser should allow the cookie to be accessed by client-side JavaScript. The

--- a/test/Microsoft.AspNet.Session.Tests/SessionTests.cs
+++ b/test/Microsoft.AspNet.Session.Tests/SessionTests.cs
@@ -33,7 +33,7 @@ namespace Microsoft.AspNet.Session
             }))
             {
                 var client = server.CreateClient();
-                var response = await client.GetAsync("/");
+                var response = await client.GetAsync(SessionDefaults.CookiePath);
                 response.EnsureSuccessStatusCode();
                 IEnumerable<string> values;
                 Assert.False(response.Headers.TryGetValues("Set-Cookie", out values));
@@ -57,7 +57,7 @@ namespace Microsoft.AspNet.Session
             }))
             {
                 var client = server.CreateClient();
-                var response = await client.GetAsync("/");
+                var response = await client.GetAsync(SessionDefaults.CookiePath);
                 response.EnsureSuccessStatusCode();
                 IEnumerable<string> values;
                 Assert.True(response.Headers.TryGetValues("Set-Cookie", out values));
@@ -94,9 +94,9 @@ namespace Microsoft.AspNet.Session
 
                 client = server.CreateClient();
                 client.DefaultRequestHeaders.Add("Cookie", response.Headers.GetValues("Set-Cookie"));
-                Assert.Equal("1", await client.GetStringAsync("/"));
-                Assert.Equal("2", await client.GetStringAsync("/"));
-                Assert.Equal("3", await client.GetStringAsync("/"));
+                Assert.Equal("1", await client.GetStringAsync(SessionDefaults.CookiePath));
+                Assert.Equal("2", await client.GetStringAsync(SessionDefaults.CookiePath));
+                Assert.Equal("3", await client.GetStringAsync(SessionDefaults.CookiePath));
             }
         }
 
@@ -207,7 +207,7 @@ namespace Microsoft.AspNet.Session
             }))
             {
                 var client = server.CreateClient();
-                var response = await client.GetAsync("/");
+                var response = await client.GetAsync(SessionDefaults.CookiePath);
                 response.EnsureSuccessStatusCode();
                 Assert.Single(sink.Writes);
                 Assert.True(((ILoggerStructure)sink.Writes[0].State).Format().Contains("started"));

--- a/test/Microsoft.AspNet.Session.Tests/project.json
+++ b/test/Microsoft.AspNet.Session.Tests/project.json
@@ -3,7 +3,7 @@
     "Microsoft.AspNet.Session": "1.0.0-*",
     "Microsoft.AspNet.RequestContainer": "1.0.0-*",
     "Microsoft.AspNet.TestHost": "1.0.0-*",
-    "Microsoft.AspNet.Testing.Logging": "1.0.0-*",
+	"Microsoft.AspNet.Testing.Logging": "1.0.0-*",
     "xunit.runner.kre": "1.0.0-*"
   },
   "commands": {


### PR DESCRIPTION
Adding CookiePath to SessionDefaults with the value "/" will remove the duplication in SessionOptions, SessionMiddleware [Refactoring]