### PR TITLE
Add Secure cookie flag option to session cookie

### DIFF
--- a/src/Microsoft.AspNet.Session/CookieSecureOption.cs
+++ b/src/Microsoft.AspNet.Session/CookieSecureOption.cs
@@ -1,4 +1,7 @@
-﻿using System;
+﻿// Copyright (c) Microsoft Open Technologies, Inc. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;

--- a/src/Microsoft.AspNet.Session/CookieSecureOption.cs
+++ b/src/Microsoft.AspNet.Session/CookieSecureOption.cs
@@ -1,0 +1,36 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+
+namespace Microsoft.AspNet.Session
+{
+    /// <summary>
+    /// Determines how the identity cookie's security property is set.
+    /// </summary>
+    public enum CookieSecureOption
+    {
+        /// <summary>
+        /// If the URI that provides the cookie is HTTPS, then the cookie will only be returned to the server on 
+        /// subsequent HTTPS requests. Otherwise if the URI that provides the cookie is HTTP, then the cookie will 
+        /// be returned to the server on all HTTP and HTTPS requests. This is the default value because it ensures
+        /// HTTPS for all authenticated requests on deployed servers, and also supports HTTP for localhost development 
+        /// and for servers that do not have HTTPS support.
+        /// </summary>
+        SameAsRequest,
+
+        /// <summary>
+        /// CookieOptions.Secure is never marked true. Use this value when your login page is HTTPS, but other pages
+        /// on the site which are HTTP also require authentication information. This setting is not recommended because
+        /// the authentication information provided with an HTTP request may be observed and used by other computers
+        /// on your local network or wireless connection.
+        /// </summary>
+        Never,
+
+        /// <summary>
+        /// CookieOptions.Secure is always marked true. Use this value when your login page and all subsequent pages
+        /// requiring the authenticated identity are HTTPS. Local development will also need to be done with HTTPS urls.
+        /// </summary>
+        Always,
+    }
+}

--- a/src/Microsoft.AspNet.Session/SessionDefaults.cs
+++ b/src/Microsoft.AspNet.Session/SessionDefaults.cs
@@ -9,5 +9,6 @@ namespace Microsoft.AspNet.Session
     {
         public static string CookieName = ".AspNet.Session";
         public static string CookiePath = "/";
+        public static CookieSecureOption CookieSecure = CookieSecureOption.SameAsRequest;
     }
 }

--- a/src/Microsoft.AspNet.Session/SessionDefaults.cs
+++ b/src/Microsoft.AspNet.Session/SessionDefaults.cs
@@ -10,5 +10,6 @@ namespace Microsoft.AspNet.Session
         public static string CookieName = ".AspNet.Session";
         public static string CookiePath = "/";
         public static CookieSecureOption CookieSecure = CookieSecureOption.SameAsRequest;
+        public static bool CookieHTTPOnly = true;
     }
 }

--- a/src/Microsoft.AspNet.Session/SessionMiddleware.cs
+++ b/src/Microsoft.AspNet.Session/SessionMiddleware.cs
@@ -130,6 +130,15 @@ namespace Microsoft.AspNet.Session
                     Path = _options.CookiePath ?? SessionDefaults.CookiePath,
                 };
 
+                if (_options.CookieSecure == CookieSecureOption.SameAsRequest)
+                {
+                    cookieOptions.Secure = _context.Request.IsHttps;
+                }
+                else
+                {
+                    cookieOptions.Secure = _options.CookieSecure == CookieSecureOption.Always;
+                }
+
                 _context.Response.Cookies.Append(_options.CookieName, _sessionKey, cookieOptions);
 
                 _context.Response.Headers.Set(

--- a/src/Microsoft.AspNet.Session/SessionOptions.cs
+++ b/src/Microsoft.AspNet.Session/SessionOptions.cs
@@ -36,6 +36,13 @@ namespace Microsoft.AspNet.Session
         public TimeSpan IdleTimeout { get; set; } = TimeSpan.FromMinutes(20);
 
         /// <summary>
+        /// Determines if the cookie should only be transmitted on HTTPS request. The default is to limit the cookie
+        /// to HTTPS requests if the page which is doing the SignIn is also HTTPS. If you have an HTTPS sign in page
+        /// and portions of your site are HTTP you may need to change this value.
+        /// </summary>
+        public CookieSecureOption CookieSecure { get; set; } = SessionDefaults.CookieSecure;
+
+        /// <summary>
         /// Gets or sets the session storage manager. This overrides any session store passed into the middleware constructor.
         /// </summary>
         public ISessionStore Store { get; set; }

--- a/src/Microsoft.AspNet.Session/SessionOptions.cs
+++ b/src/Microsoft.AspNet.Session/SessionOptions.cs
@@ -27,7 +27,7 @@ namespace Microsoft.AspNet.Session
         /// default is true, which means the cookie will only be passed to HTTP requests and is not made available
         /// to script on the page.
         /// </summary>
-        public bool CookieHttpOnly { get; set; } = true;
+        public bool CookieHttpOnly { get; set; } = SessionDefaults.CookieHTTPOnly;
 
         /// <summary>
         /// The IdleTimeout indicates how long the session can be idle before its contents are abandoned. Each session access

--- a/test/Microsoft.AspNet.Session.Tests/SessionTests.cs
+++ b/test/Microsoft.AspNet.Session.Tests/SessionTests.cs
@@ -268,5 +268,140 @@ namespace Microsoft.AspNet.Session
                 Assert.Equal(LogLevel.Warning, sink.Writes[1].LogLevel);
             }
         }
+
+        [Fact]
+        public async Task SettingSecureCookieOptionToNeverWillEnsureSecureFlagNotSet()
+        {
+            using (var server = TestServer.Create(app =>
+            {
+                app.UseInMemorySession(null, cookieoption => cookieoption.CookieSecure = CookieSecureOption.Never);
+                app.Run(context =>
+                {
+                    Assert.Null(context.Session.GetString("Key"));
+                    context.Session.SetString("Key", "Value");
+                    Assert.Equal("Value", context.Session.GetString("Key"));
+                    return Task.FromResult(0);
+                });
+            },
+            services => services.AddOptions()))
+            {
+                var client = server.CreateClient();
+                var response = await client.GetAsync(string.Empty);
+                response.EnsureSuccessStatusCode();
+                IEnumerable<string> values;
+                Assert.True(response.Headers.TryGetValues("Set-Cookie", out values));
+                Assert.Equal(1, values.Count());
+                Assert.True(!string.IsNullOrWhiteSpace(values.First()));
+                Assert.DoesNotContain("secure", values.First());
+            }
+        }
+
+        [Fact]
+        public async Task SettingSecureCookieOptionToAlwaysWillEnsureSecureFlagSet()
+        {
+            using (var server = TestServer.Create(app =>
+            {
+                app.UseInMemorySession(null, cookieoption => cookieoption.CookieSecure = CookieSecureOption.Always);
+                app.Run(context =>
+                {
+                    Assert.Null(context.Session.GetString("Key"));
+                    context.Session.SetString("Key", "Value");
+                    Assert.Equal("Value", context.Session.GetString("Key"));
+                    return Task.FromResult(0);
+                });
+            },
+            services => services.AddOptions()))
+            {
+                var client = server.CreateClient();
+                var response = await client.GetAsync(string.Empty);
+                response.EnsureSuccessStatusCode();
+                IEnumerable<string> values;
+                Assert.True(response.Headers.TryGetValues("Set-Cookie", out values));
+                Assert.Equal(1, values.Count());
+                Assert.True(!string.IsNullOrWhiteSpace(values.First()));
+                Assert.Contains("secure", values.First());
+            }
+        }
+
+        [Fact]
+        public async Task SettingSecureCookieOptionToSameAsRequestWillEnsureSecureFlagNotSetWhileNotUsingSSL()
+        {
+            using (var server = TestServer.Create(app =>
+            {
+                app.UseInMemorySession(null, cookieoption => cookieoption.CookieSecure = CookieSecureOption.SameAsRequest);
+                app.Run(context =>
+                {
+                    Assert.Null(context.Session.GetString("Key"));
+                    context.Session.SetString("Key", "Value");
+                    Assert.Equal("Value", context.Session.GetString("Key"));
+                    return Task.FromResult(0);
+                });
+            },
+            services => services.AddOptions()))
+            {
+                var client = server.CreateClient();
+                var response = await client.GetAsync(string.Empty);
+                response.EnsureSuccessStatusCode();
+                IEnumerable<string> values;
+                Assert.True(response.Headers.TryGetValues("Set-Cookie", out values));
+                Assert.Equal(1, values.Count());
+                Assert.True(!string.IsNullOrWhiteSpace(values.First()));
+                Assert.DoesNotContain("secure", values.First());
+            }
+        }
+
+        [Fact]
+        public async Task SettingHTTPOnlyCookieOptionToTrueWillEnsureHTTPOnlyFlagSet()
+        {
+            using (var server = TestServer.Create(app =>
+            {
+                app.UseInMemorySession(null, cookieoption => cookieoption.CookieHttpOnly = true);
+                app.Run(context =>
+                {
+                    Assert.Null(context.Session.GetString("Key"));
+                    context.Session.SetString("Key", "Value");
+                    Assert.Equal("Value", context.Session.GetString("Key"));
+                    return Task.FromResult(0);
+                });
+            },
+            services => services.AddOptions()))
+            {
+                var client = server.CreateClient();
+                var response = await client.GetAsync(string.Empty);
+                response.EnsureSuccessStatusCode();
+                IEnumerable<string> values;
+                Assert.True(response.Headers.TryGetValues("Set-Cookie", out values));
+                Assert.Equal(1, values.Count());
+                Assert.True(!string.IsNullOrWhiteSpace(values.First()));
+                Assert.Contains("httponly", values.First());
+            }
+        }
+
+        [Fact]
+        public async Task SettingHTTPOnlyCookieOptionToFalseWillEnsureHTTPOnlyFlagNotSet()
+        {
+            using (var server = TestServer.Create(app =>
+            {
+                app.UseInMemorySession(null, cookieoption => cookieoption.CookieHttpOnly = false);
+                app.Run(context =>
+                {
+                    Assert.Null(context.Session.GetString("Key"));
+                    context.Session.SetString("Key", "Value");
+                    Assert.Equal("Value", context.Session.GetString("Key"));
+                    return Task.FromResult(0);
+                });
+            },
+            services => services.AddOptions()))
+            {
+                var client = server.CreateClient();
+                var response = await client.GetAsync(string.Empty);
+                response.EnsureSuccessStatusCode();
+                IEnumerable<string> values;
+                Assert.True(response.Headers.TryGetValues("Set-Cookie", out values));
+                Assert.Equal(1, values.Count());
+                Assert.True(!string.IsNullOrWhiteSpace(values.First()));
+                Assert.DoesNotContain("httponly", values.First());
+            }
+        }
     }
 }


### PR DESCRIPTION
The session cookie needs the ability to have the 'Secure' flag set.  This PR adds support for always use secure flag, never use secure flag and use secure flag only if initial request is SSL.

Included unit tests for Secure flag as well as HTTPOnly flag.
