### PR TITLE
Make 'SessionDefaults' fields as Constants

### DIFF
--- a/src/Microsoft.AspNet.Session/SessionDefaults.cs
+++ b/src/Microsoft.AspNet.Session/SessionDefaults.cs
@@ -7,7 +7,7 @@ namespace Microsoft.AspNet.Session
 {
     public static class SessionDefaults
     {
-        public static string CookieName = ".AspNet.Session";
-        public static string CookiePath = "/";
+        public static readonly string CookieName = ".AspNet.Session";
+        public static readonly string CookiePath = "/";
     }
 }


### PR DESCRIPTION
While ```SessionDefaults``` contains public fields that contains default values, it will be more convenience to make them constants by adding ```readonly``` modifier