### PR TITLE
Remove unused dnx command

### DIFF
--- a/samples/SessionSample/project.json
+++ b/samples/SessionSample/project.json
@@ -1,7 +1,6 @@
 {
     "commands": {
-        "web": "Microsoft.AspNet.Hosting server=Microsoft.AspNet.Server.WebListener server.urls=http://localhost:5001",
-        "install-sqlservercache": "Microsoft.Framework.Caching.SqlServer"
+        "web": "Microsoft.AspNet.Hosting server=Microsoft.AspNet.Server.WebListener server.urls=http://localhost:5001"
     },
     "dependencies": {
         "Microsoft.AspNet.Server.IIS": "1.0.0-*",


### PR DESCRIPTION
Based on issue #50, I notice that **install-sqlservercache** command is never used 