### PR TITLE
Filter log messages

### DIFF
--- a/test/Microsoft.AspNet.Session.Tests/SessionTests.cs
+++ b/test/Microsoft.AspNet.Session.Tests/SessionTests.cs
@@ -240,9 +240,12 @@ namespace Microsoft.AspNet.Session
                 var client = server.CreateClient();
                 var response = await client.GetAsync(string.Empty);
                 response.EnsureSuccessStatusCode();
-                Assert.Single(sink.Writes);
-                Assert.Contains("started", sink.Writes[0].State.ToString());
-                Assert.Equal(LogLevel.Information, sink.Writes[0].LogLevel);
+
+                var sessionLogMessages = sink.Writes.OnlyMessagesFromSource<DistributedSession>().ToArray();
+
+                Assert.Single(sessionLogMessages);
+                Assert.Contains("started", sessionLogMessages[0].State.ToString());
+                Assert.Equal(LogLevel.Information, sessionLogMessages[0].LogLevel);
             }
         }
 
@@ -287,11 +290,14 @@ namespace Microsoft.AspNet.Session
                 client.DefaultRequestHeaders.Add("Cookie", new CookieHeaderValue(cookie.Name, cookie.Value).ToString());
                 Thread.Sleep(50);
                 Assert.Equal("2", await client.GetStringAsync("/second"));
-                Assert.Equal(2, sink.Writes.Count);
-                Assert.Contains("started", sink.Writes[0].State.ToString());
-                Assert.Contains("expired", sink.Writes[1].State.ToString());
-                Assert.Equal(LogLevel.Information, sink.Writes[0].LogLevel);
-                Assert.Equal(LogLevel.Warning, sink.Writes[1].LogLevel);
+
+                var sessionLogMessages = sink.Writes.OnlyMessagesFromSource<DistributedSession>().ToArray();
+
+                Assert.Equal(2, sessionLogMessages.Length);
+                Assert.Contains("started", sessionLogMessages[0].State.ToString());
+                Assert.Contains("expired", sessionLogMessages[1].State.ToString());
+                Assert.Equal(LogLevel.Information, sessionLogMessages[0].LogLevel);
+                Assert.Equal(LogLevel.Warning, sessionLogMessages[1].LogLevel);
             }
         }
 

--- a/test/Microsoft.AspNet.Session.Tests/TestExtensions.cs
+++ b/test/Microsoft.AspNet.Session.Tests/TestExtensions.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using Microsoft.Extensions.Logging.Testing;
+
+namespace Microsoft.AspNet.Session
+{
+    public static class TestExtensions
+    {
+        public static IEnumerable<WriteContext> OnlyMessagesFromSource<T>(this IEnumerable<WriteContext> source)
+        {
+            return source.Where(message => message.LoggerName.Equals(typeof(T).FullName, StringComparison.Ordinal));
+        }
+    }
+}


### PR DESCRIPTION
Fix the tests. They broke because hosting logs more messages now. Changed the tests to be more robust and only look for the session logging messages.

Please review @Tratcher @kichalla 

@muratg can this go in dev for rc1? It is blocking the build