### PR TITLE
Add a session Id

### DIFF
--- a/samples/SessionSample/Properties/launchSettings.json
+++ b/samples/SessionSample/Properties/launchSettings.json
@@ -1,0 +1,25 @@
+{
+  "iisSettings": {
+    "windowsAuthentication": false,
+    "anonymousAuthentication": true,
+    "iisExpress": {
+      "applicationUrl": "http://localhost:2481/",
+      "sslPort": 0
+    }
+  },
+  "profiles": {
+    "IIS Express": {
+      "commandName": "IISExpress",
+      "launchBrowser": true,
+      "environmentVariables": {
+        "Hosting:Environment": "Development"
+      }
+    },
+    "web": {
+      "commandName": "web",
+      "environmentVariables": {
+        "Hosting:Environment": "Development"
+      }
+    }
+  }
+}

--- a/src/Microsoft.AspNetCore.Session/DistributedSessionStore.cs
+++ b/src/Microsoft.AspNetCore.Session/DistributedSessionStore.cs
@@ -37,11 +37,11 @@ namespace Microsoft.AspNetCore.Session
             }
         }
 
-        public ISession Create(string sessionId, TimeSpan idleTimeout, Func<bool> tryEstablishSession, bool isNewSessionKey)
+        public ISession Create(string sessionKey, TimeSpan idleTimeout, Func<bool> tryEstablishSession, bool isNewSessionKey)
         {
-            if (string.IsNullOrEmpty(sessionId))
+            if (string.IsNullOrEmpty(sessionKey))
             {
-                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(sessionId));
+                throw new ArgumentException(Resources.ArgumentCannotBeNullOrEmpty, nameof(sessionKey));
             }
 
             if (tryEstablishSession == null)
@@ -49,7 +49,7 @@ namespace Microsoft.AspNetCore.Session
                 throw new ArgumentNullException(nameof(tryEstablishSession));
             }
 
-            return new DistributedSession(_cache, sessionId, idleTimeout, tryEstablishSession, _loggerFactory, isNewSessionKey);
+            return new DistributedSession(_cache, sessionKey, idleTimeout, tryEstablishSession, _loggerFactory, isNewSessionKey);
         }
     }
 }

--- a/src/Microsoft.AspNetCore.Session/ISessionStore.cs
+++ b/src/Microsoft.AspNetCore.Session/ISessionStore.cs
@@ -10,6 +10,6 @@ namespace Microsoft.AspNetCore.Session
     {
         bool IsAvailable { get; }
 
-        ISession Create(string sessionId, TimeSpan idleTimeout, Func<bool> tryEstablishSession, bool isNewSessionKey);
+        ISession Create(string sessionKey, TimeSpan idleTimeout, Func<bool> tryEstablishSession, bool isNewSessionKey);
     }
 }

--- a/src/Microsoft.AspNetCore.Session/LoggingExtensions.cs
+++ b/src/Microsoft.AspNetCore.Session/LoggingExtensions.cs
@@ -9,7 +9,9 @@ namespace Microsoft.Extensions.Logging
     {
         private static Action<ILogger, Exception> _errorClosingTheSession;
         private static Action<ILogger, string, Exception> _accessingExpiredSession;
-        private static Action<ILogger, string, Exception> _sessionStarted;
+        private static Action<ILogger, string, string, Exception> _sessionStarted;
+        private static Action<ILogger, string, string, int, Exception> _sessionLoaded;
+        private static Action<ILogger, string, string, int, Exception> _sessionStored;
 
         static LoggingExtensions()
         {
@@ -20,11 +22,19 @@ namespace Microsoft.Extensions.Logging
             _accessingExpiredSession = LoggerMessage.Define<string>(
                 eventId: 2,
                 logLevel: LogLevel.Warning,
-                formatString: "Accessing expired session {SessionId}");
-            _sessionStarted = LoggerMessage.Define<string>(
+                formatString: "Accessing expired session; Key:{sessionKey}");
+            _sessionStarted = LoggerMessage.Define<string, string>(
                 eventId: 3,
                 logLevel: LogLevel.Information,
-                formatString: "Session {SessionId} started");
+                formatString: "Session started; Key:{sessionKey}, Id:{sessionId}");
+            _sessionLoaded = LoggerMessage.Define<string, string, int>(
+                eventId: 4,
+                logLevel: LogLevel.Debug,
+                formatString: "Session loaded; Key:{sessionKey}, Id:{sessionId}, Count:{count}");
+            _sessionStored = LoggerMessage.Define<string, string, int>(
+                eventId: 5,
+                logLevel: LogLevel.Debug,
+                formatString: "Session stored; Key:{sessionKey}, Id:{sessionId}, Count:{count}");
         }
 
         public static void ErrorClosingTheSession(this ILogger logger, Exception exception)
@@ -32,14 +42,24 @@ namespace Microsoft.Extensions.Logging
             _errorClosingTheSession(logger, exception);
         }
 
-        public static void AccessingExpiredSession(this ILogger logger, string sessionId)
+        public static void AccessingExpiredSession(this ILogger logger, string sessionKey)
         {
-            _accessingExpiredSession(logger, sessionId, null);
+            _accessingExpiredSession(logger, sessionKey, null);
         }
 
-        public static void SessionStarted(this ILogger logger, string sessionId)
+        public static void SessionStarted(this ILogger logger, string sessionKey, string sessionId)
         {
-            _sessionStarted(logger, sessionId, null);
+            _sessionStarted(logger, sessionKey, sessionId, null);
+        }
+
+        public static void SessionLoaded(this ILogger logger, string sessionKey, string sessionId, int count)
+        {
+            _sessionLoaded(logger, sessionKey, sessionId, count, null);
+        }
+
+        public static void SessionStored(this ILogger logger, string sessionKey, string sessionId, int count)
+        {
+            _sessionStored(logger, sessionKey, sessionId, count, null);
         }
     }
 }

--- a/test/Microsoft.AspNetCore.Session.Tests/SessionTests.cs
+++ b/test/Microsoft.AspNetCore.Session.Tests/SessionTests.cs
@@ -262,9 +262,11 @@ namespace Microsoft.AspNetCore.Session
 
                 var sessionLogMessages = sink.Writes.OnlyMessagesFromSource<DistributedSession>().ToArray();
 
-                Assert.Single(sessionLogMessages);
+                Assert.Equal(2, sessionLogMessages.Length);
                 Assert.Contains("started", sessionLogMessages[0].State.ToString());
                 Assert.Equal(LogLevel.Information, sessionLogMessages[0].LogLevel);
+                Assert.Contains("stored", sessionLogMessages[1].State.ToString());
+                Assert.Equal(LogLevel.Debug, sessionLogMessages[1].LogLevel);
             }
         }
 
@@ -315,11 +317,13 @@ namespace Microsoft.AspNetCore.Session
 
                 var sessionLogMessages = sink.Writes.OnlyMessagesFromSource<DistributedSession>().ToArray();
 
-                Assert.Equal(2, sessionLogMessages.Length);
+                Assert.Equal(3, sessionLogMessages.Length);
                 Assert.Contains("started", sessionLogMessages[0].State.ToString());
-                Assert.Contains("expired", sessionLogMessages[1].State.ToString());
+                Assert.Contains("stored", sessionLogMessages[1].State.ToString());
+                Assert.Contains("expired", sessionLogMessages[2].State.ToString());
                 Assert.Equal(LogLevel.Information, sessionLogMessages[0].LogLevel);
-                Assert.Equal(LogLevel.Warning, sessionLogMessages[1].LogLevel);
+                Assert.Equal(LogLevel.Debug, sessionLogMessages[1].LogLevel);
+                Assert.Equal(LogLevel.Warning, sessionLogMessages[2].LogLevel);
             }
         }
 


### PR DESCRIPTION
#96 
Depends on https://github.com/aspnet/HttpAbstractions/commit/0b2200010faf0e1de87415a58e2c3513e309d0f6

People keep asking for a unique session id. The cookie is not a good id because it can stick around longer than the cache entry. However, we can embed a unique id directly in the session that's stored in the cache entry.

@blowdart  @muratg 