### PR TITLE
Added session key generator interface and implementation.

### DIFF
--- a/src/Microsoft.AspNetCore.Session/ISessionKeyGenerator.cs
+++ b/src/Microsoft.AspNetCore.Session/ISessionKeyGenerator.cs
@@ -1,0 +1,10 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+namespace Microsoft.AspNetCore.Session
+{
+    public interface ISessionKeyGenerator
+    {
+        string GetNewSessionKey(int sessionKeyLength);
+    }
+}

--- a/src/Microsoft.AspNetCore.Session/ISessionKeyGenerator.cs
+++ b/src/Microsoft.AspNetCore.Session/ISessionKeyGenerator.cs
@@ -5,6 +5,7 @@ namespace Microsoft.AspNetCore.Session
 {
     public interface ISessionKeyGenerator
     {
-        string GetNewSessionKey(int sessionKeyLength);
+        string GetNewSessionKey();
+        int SessionKeyLength { get; }
     }
 }

--- a/src/Microsoft.AspNetCore.Session/SessionKeyGenerator.cs
+++ b/src/Microsoft.AspNetCore.Session/SessionKeyGenerator.cs
@@ -1,0 +1,20 @@
+﻿// Copyright (c) .NET Foundation. All rights reserved.
+// Licensed under the Apache License, Version 2.0. See License.txt in the project root for license information.
+
+using System;
+using System.Security.Cryptography;
+
+namespace Microsoft.AspNetCore.Session
+{
+    public class SessionKeyGenerator: ISessionKeyGenerator
+    {
+        private static readonly RandomNumberGenerator CryptoRandom = RandomNumberGenerator.Create();
+
+        public virtual string GetNewSessionKey(int sessionKeyLength)
+        {
+            var guidBytes = new byte[16];
+            CryptoRandom.GetBytes(guidBytes);
+            return new Guid(guidBytes).ToString();
+        }
+    }
+}

--- a/src/Microsoft.AspNetCore.Session/SessionKeyGenerator.cs
+++ b/src/Microsoft.AspNetCore.Session/SessionKeyGenerator.cs
@@ -10,11 +10,13 @@ namespace Microsoft.AspNetCore.Session
     {
         private static readonly RandomNumberGenerator CryptoRandom = RandomNumberGenerator.Create();
 
-        public virtual string GetNewSessionKey(int sessionKeyLength)
+        public virtual string GetNewSessionKey()
         {
             var guidBytes = new byte[16];
             CryptoRandom.GetBytes(guidBytes);
             return new Guid(guidBytes).ToString();
         }
+
+        public int SessionKeyLength => 36; //"382c74c3-721d-4f34-80e5-57657b6cbc27"
     }
 }

--- a/src/Microsoft.AspNetCore.Session/SessionMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Session/SessionMiddleware.cs
@@ -26,6 +26,25 @@ namespace Microsoft.AspNetCore.Session
         private readonly IDataProtector _dataProtector;
         private readonly ISessionKeyGenerator _sessionKeyGenerator;
 
+
+        /// <summary>
+        /// Creates a new <see cref="SessionMiddleware"/>.
+        /// </summary>
+        /// <param name="next">The <see cref="RequestDelegate"/> representing the next middleware in the pipeline.</param>
+        /// <param name="loggerFactory">The <see cref="ILoggerFactory"/> representing the factory that used to create logger instances.</param>
+        /// <param name="dataProtectionProvider">The <see cref="IDataProtectionProvider"/> used to protect and verify the cookie.</param>
+        /// <param name="sessionStore">The <see cref="ISessionStore"/> representing the session store.</param>
+        /// <param name="options">The session configuration options.</param>
+        public SessionMiddleware(
+            RequestDelegate next,
+            ILoggerFactory loggerFactory,
+            IDataProtectionProvider dataProtectionProvider,
+            ISessionStore sessionStore,
+            IOptions<SessionOptions> options)
+            : this(next, loggerFactory, dataProtectionProvider, sessionStore, options, new SessionKeyGenerator())
+        {
+        }
+
         /// <summary>
         /// Creates a new <see cref="SessionMiddleware"/>.
         /// </summary>
@@ -96,8 +115,11 @@ namespace Microsoft.AspNetCore.Session
             {
                 // No valid cookie, new session.
                 sessionKey = _sessionKeyGenerator.GetNewSessionKey();
-                if(sessionKey.Length != SessionKeyLength)
-                    throw new FormatException($"Provided session key length ({sessionKey.Length}) does not match required length: {SessionKeyLength}");
+                if (sessionKey.Length != SessionKeyLength)
+                {
+                    throw new FormatException(
+                        $"Provided session key length ({sessionKey.Length}) does not match required length: {SessionKeyLength}");
+                }
                 cookieValue = CookieProtection.Protect(_dataProtector, sessionKey);
                 var establisher = new SessionEstablisher(context, cookieValue, _options);
                 tryEstablishSession = establisher.TryEstablishSession;

--- a/src/Microsoft.AspNetCore.Session/SessionMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Session/SessionMiddleware.cs
@@ -17,7 +17,7 @@ namespace Microsoft.AspNetCore.Session
     /// </summary>
     public class SessionMiddleware
     {
-        private const int SessionKeyLength = 36; // "382c74c3-721d-4f34-80e5-57657b6cbc27"
+        private int SessionKeyLength => _sessionKeyGenerator.SessionKeyLength;
         private static readonly Func<bool> ReturnTrue = () => true;
         private readonly RequestDelegate _next;
         private readonly SessionOptions _options;
@@ -95,7 +95,7 @@ namespace Microsoft.AspNetCore.Session
             if (string.IsNullOrWhiteSpace(sessionKey) || sessionKey.Length != SessionKeyLength)
             {
                 // No valid cookie, new session.
-                sessionKey = _sessionKeyGenerator.GetNewSessionKey(SessionKeyLength);
+                sessionKey = _sessionKeyGenerator.GetNewSessionKey();
                 if(sessionKey.Length != SessionKeyLength)
                     throw new FormatException($"Provided session key length ({sessionKey.Length}) does not match required length: {SessionKeyLength}");
                 cookieValue = CookieProtection.Protect(_dataProtector, sessionKey);

--- a/src/Microsoft.AspNetCore.Session/SessionMiddlewareExtensions.cs
+++ b/src/Microsoft.AspNetCore.Session/SessionMiddlewareExtensions.cs
@@ -46,5 +46,31 @@ namespace Microsoft.AspNetCore.Builder
 
             return app.UseMiddleware<SessionMiddleware>(Options.Create(options));
         }
+
+        /// <summary>
+        /// Adds the <see cref="SessionMiddleware"/> to automatically enable session state for the application.
+        /// </summary>
+        /// <param name="app">The <see cref="IApplicationBuilder"/>.</param>
+        /// <param name="options">The <see cref="SessionOptions"/>.</param>
+        /// <param name="keyGenerator">The <see cref="ISessionKeyGenerator"/> implementation.</param>
+        /// <returns>The <see cref="IApplicationBuilder"/>.</returns>
+        public static IApplicationBuilder UseSession(this IApplicationBuilder app, SessionOptions options,
+            ISessionKeyGenerator keyGenerator)
+        {
+            if (app == null)
+            {
+                throw new ArgumentNullException(nameof(app));
+            }
+            if (options == null)
+            {
+                throw new ArgumentNullException(nameof(options));
+            }
+            if (keyGenerator == null)
+            {
+                throw new ArgumentNullException(nameof(keyGenerator));
+            }
+
+            return app.UseMiddleware<SessionMiddleware>(Options.Create(options), keyGenerator);
+        }
     }
 }

--- a/src/Microsoft.AspNetCore.Session/SessionServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Session/SessionServiceCollectionExtensions.cs
@@ -25,6 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection
             }
 
             services.AddTransient<ISessionStore, DistributedSessionStore>();
+            services.AddSingleton<ISessionKeyGenerator, SessionKeyGenerator>();
             services.AddDataProtection();
             return services;
         }


### PR DESCRIPTION
Overriding the implementation through DI can provide access to session keys from outside.
It's nice extension point to allow external session management as long as SessionStore does not provide list of existing session keys. 

Addresses #133 