### PR TITLE
Bump test projects up to .NET 4.5.2

### DIFF
--- a/test/Microsoft.AspNetCore.Session.Tests/Microsoft.AspNetCore.Session.Tests.csproj
+++ b/test/Microsoft.AspNetCore.Session.Tests/Microsoft.AspNetCore.Session.Tests.csproj
@@ -3,7 +3,8 @@
   <Import Project="..\..\build\common.props" />
 
   <PropertyGroup>
-    <TargetFrameworks>netcoreapp1.1;net451</TargetFrameworks>
+    <TargetFrameworks>netcoreapp1.1;net452</TargetFrameworks>
+    <TargetFrameworks Condition=" '$(OS)' != 'Windows_NT' ">netcoreapp1.1</TargetFrameworks>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- aspnet/Testing#248
- xUnit no longer supports .NET 4.5.1
- build tests for desktop .NET only on Windows