### PR TITLE
Add configurable SameSite cookie option

### DIFF
--- a/src/Microsoft.AspNetCore.Session/SessionMiddleware.cs
+++ b/src/Microsoft.AspNetCore.Session/SessionMiddleware.cs
@@ -153,6 +153,7 @@ namespace Microsoft.AspNetCore.Session
                 var cookieOptions = new CookieOptions
                 {
                     Domain = _options.CookieDomain,
+                    SameSite = _options.SameSiteMode,
                     HttpOnly = _options.CookieHttpOnly,
                     Path = _options.CookiePath ?? SessionDefaults.CookiePath,
                 };

--- a/src/Microsoft.AspNetCore.Session/SessionOptions.cs
+++ b/src/Microsoft.AspNetCore.Session/SessionOptions.cs
@@ -37,6 +37,12 @@ namespace Microsoft.AspNetCore.Builder
         public bool CookieHttpOnly { get; set; } = true;
 
         /// <summary>
+        /// Determines if the browser should allow the cookie to be attached to same-site or cross-site requests. The
+        /// default is Lax, which means the cookie is allowed to be attached to same-site and safe cross-site requests.
+        /// </summary>
+        public SameSiteMode SameSiteMode { get; set; } = SameSiteMode.Lax;
+
+        /// <summary>
         /// Determines if the cookie should only be transmitted on HTTPS requests. 
         /// </summary>
         public CookieSecurePolicy CookieSecure { get; set; } = CookieSecurePolicy.None;


### PR DESCRIPTION
Reacting to aspnet/HttpAbstractions#843. We would like to keep the default as None since sessions may be used in cross-site requests (via redirects).