### PR TITLE
Use TryAdd for ISessionStore service

### DIFF
--- a/src/Microsoft.AspNetCore.Session/SessionServiceCollectionExtensions.cs
+++ b/src/Microsoft.AspNetCore.Session/SessionServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@
 using System;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Session;
+using Microsoft.Extensions.DependencyInjection.Extensions;
 
 namespace Microsoft.Extensions.DependencyInjection
 {
@@ -24,7 +25,7 @@ namespace Microsoft.Extensions.DependencyInjection
                 throw new ArgumentNullException(nameof(services));
             }
 
-            services.AddTransient<ISessionStore, DistributedSessionStore>();
+            services.TryAddTransient<ISessionStore, DistributedSessionStore>();
             services.AddDataProtection();
             return services;
         }


### PR DESCRIPTION
 #2755. This is the recommended pattern to allow users to override services without worrying about their call order.